### PR TITLE
fix(ui): 修复混合输入设备下边框与列宽无法用鼠标拖动 (#22)

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -69,6 +69,8 @@ declare module 'vue' {
     NModalProvider: typeof import('naive-ui')['NModalProvider']
     NPopover: typeof import('naive-ui')['NPopover']
     NProgress: typeof import('naive-ui')['NProgress']
+    NRadioButton: typeof import('naive-ui')['NRadioButton']
+    NRadioGroup: typeof import('naive-ui')['NRadioGroup']
     NSelect: typeof import('naive-ui')['NSelect']
     NSpace: typeof import('naive-ui')['NSpace']
     NSpin: typeof import('naive-ui')['NSpin']

--- a/src/components/CanvasList/ListHeader.vue
+++ b/src/components/CanvasList/ListHeader.vue
@@ -37,10 +37,7 @@
         <div
           v-if="colIdx < visibleColumns.length"
           class="col-resizer"
-          @mousedown="onResizerMouseDown($event, col)"
-          @touchstart="onResizerTouchStart($event, col)"
-          @touchmove="onResizerTouchMove($event)"
-          @touchend="onResizerTouchEnd($event)"
+          @pointerdown="onResizerPointerDown($event, col)"
         ></div>
       </div>
     </div>
@@ -102,99 +99,61 @@ const showColumnMenu = defineModel<boolean>('showHeaderMenu', { default: false }
 const columnMenuX = ref(0)
 const columnMenuY = ref(0)
 
-function onResizerTouchStart(e: TouchEvent, col: { key: string; width: number }) {
+// 使用 Pointer Events 统一处理鼠标 / 触屏 / 触控笔，避免在
+// navigator.maxTouchPoints > 0 的混合设备上鼠标事件被误屏蔽
+function onResizerPointerDown(e: PointerEvent, col: { key: string; width: number }) {
+  if (e.button !== 0 && e.pointerType === 'mouse') {
+    return
+  }
   e.preventDefault()
   e.stopPropagation()
-  if (e.touches.length !== 1) {
-    return
-  }
-  const dom = e.target as HTMLElement
+  const dom = e.currentTarget as HTMLElement
   dom.classList.add('active')
-  resizing.value = true
-  resizeColKey.value = col.key
-  startX.value = e.touches[0].clientX
-  startWidth.value = col.width
-  if (headerRef.value) {
-    headerLeft.value = headerRef.value.getBoundingClientRect().left
-  } else {
-    headerLeft.value = 0
-  }
-  resizeLineX.value = e.touches[0].clientX - headerLeft.value
-  document.body.style.cursor = 'col-resize'
-}
-
-function onResizerTouchMove(e: TouchEvent) {
-  if (!resizing.value || e.touches.length !== 1) {
-    return
-  }
-  resizeLineX.value = e.touches[0].clientX - headerLeft.value
-  const touch = e.changedTouches[0]
-  const delta = touch.clientX - startX.value
-  const newWidth = Math.max(getMinWidth(resizeColKey.value), startWidth.value + delta)
-  if (resizeColKey.value) {
-    torrentStore.updateColumnWidth(resizeColKey.value, newWidth)
-  }
-}
-
-function onResizerTouchEnd(e: TouchEvent) {
-  if (!resizing.value) {
-    return
-  }
-  const dom = e.target as HTMLElement
-  dom.classList.remove('active')
-  const touch = e.changedTouches[0]
-  const delta = touch.clientX - startX.value
-  const newWidth = Math.max(getMinWidth(resizeColKey.value), startWidth.value + delta)
-  if (resizeColKey.value) {
-    torrentStore.updateColumnWidth(resizeColKey.value, newWidth)
-  }
-  resizing.value = false
-  resizeColKey.value = null
-  document.body.style.cursor = ''
-}
-
-function onResizerMouseDown(e: MouseEvent, col: { key: string; width: number }) {
   resizing.value = true
   resizeColKey.value = col.key
   startX.value = e.clientX
   startWidth.value = col.width
-  if (headerRef.value) {
-    headerLeft.value = headerRef.value.getBoundingClientRect().left
-  } else {
-    headerLeft.value = 0
-  }
+  headerLeft.value = headerRef.value ? headerRef.value.getBoundingClientRect().left : 0
   resizeLineX.value = e.clientX - headerLeft.value
   document.body.style.cursor = 'col-resize'
-  window.addEventListener('mousemove', onResizerMouseMove)
-  window.addEventListener('mouseup', onResizerMouseUp)
-}
 
-function onResizerMouseMove(e: MouseEvent) {
-  if (!resizing.value) {
-    return
+  const pointerId = e.pointerId
+  try {
+    dom.setPointerCapture(pointerId)
+  } catch {
+    // 忽略不支持的浏览器
   }
-  resizeLineX.value = e.clientX - headerLeft.value
-  const delta = e.clientX - startX.value
-  const newWidth = Math.max(getMinWidth(resizeColKey.value), startWidth.value + delta)
-  if (resizeColKey.value) {
-    torrentStore.updateColumnWidth(resizeColKey.value, newWidth)
-  }
-}
 
-function onResizerMouseUp(e: MouseEvent) {
-  if (!resizing.value) {
-    return
+  function onMove(evt: PointerEvent) {
+    if (!resizing.value || evt.pointerId !== pointerId) {
+      return
+    }
+    resizeLineX.value = evt.clientX - headerLeft.value
+    const delta = evt.clientX - startX.value
+    const newWidth = Math.max(getMinWidth(resizeColKey.value), startWidth.value + delta)
+    if (resizeColKey.value) {
+      torrentStore.updateColumnWidth(resizeColKey.value, newWidth)
+    }
   }
-  const delta = e.clientX - startX.value
-  const newWidth = Math.max(getMinWidth(resizeColKey.value), startWidth.value + delta)
-  if (resizeColKey.value) {
-    torrentStore.updateColumnWidth(resizeColKey.value, newWidth)
+
+  function cleanup() {
+    dom.classList.remove('active')
+    resizing.value = false
+    resizeColKey.value = null
+    document.body.style.cursor = ''
+    try {
+      dom.releasePointerCapture(pointerId)
+    } catch {
+      // 忽略
+    }
+    dom.removeEventListener('pointermove', onMove)
+    dom.removeEventListener('pointerup', cleanup)
+    dom.removeEventListener('pointercancel', cleanup)
   }
-  resizing.value = false
-  resizeColKey.value = null
-  document.body.style.cursor = ''
-  window.removeEventListener('mousemove', onResizerMouseMove)
-  window.removeEventListener('mouseup', onResizerMouseUp)
+
+  dom.addEventListener('pointermove', onMove)
+  dom.addEventListener('pointerup', cleanup)
+  dom.addEventListener('pointercancel', cleanup)
 }
 
 function onTableHeaderContextMenu(e: MouseEvent) {
@@ -283,6 +242,9 @@ function onCheckboxChange(checked: boolean) {
   z-index: 2;
   background: transparent;
   transition: background 0.2s;
+  // 让浏览器把所有方向的拖动都交给我们处理，避免触屏滚动抢占事件
+  touch-action: none;
+  -ms-touch-action: none;
   &:hover {
     background-color: var(--border-color);
   }

--- a/src/components/ResizeHorizontalLine.vue
+++ b/src/components/ResizeHorizontalLine.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="resizer-horizontal" @mousedown="onResizeMouseDown" @touchstart="onResizeTouchStart"></div>
+  <div class="resizer-horizontal" @pointerdown="onResizePointerDown"></div>
 </template>
 
 <script setup lang="ts">
@@ -14,11 +14,7 @@ const props = withDefaults(
 )
 
 const containerHeight = defineModel<number>('containerHeight', { required: true })
-const { onResizeMouseDown, onResizeTouchStart } = useVerticalResize(
-  containerHeight,
-  props.minContainerHeight,
-  props.maxContainerHeight
-)
+const { onResizePointerDown } = useVerticalResize(containerHeight, props.minContainerHeight, props.maxContainerHeight)
 </script>
 
 <style scoped lang="less">
@@ -29,6 +25,11 @@ const { onResizeMouseDown, onResizeTouchStart } = useVerticalResize(
   transition: background 0.2s;
   width: 100%;
   z-index: 10;
+  // 让浏览器把所有方向的拖动都交给我们处理，避免触屏滚动抢占事件
+  touch-action: none;
+  -ms-touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
 }
 .resizer-horizontal:hover,
 .resizer-horizontal.active {

--- a/src/components/ResizeLine.vue
+++ b/src/components/ResizeLine.vue
@@ -1,10 +1,5 @@
 <template>
-  <div
-    class="resizer-line"
-    @mousedown="onResizeMouseDown"
-    @touchstart="onResizeTouchStart"
-    :style="{ width: lineWidth + 'px' }"
-  ></div>
+  <div class="resizer-line" @pointerdown="onResizePointerDown" :style="{ width: lineWidth + 'px' }"></div>
 </template>
 
 <script setup lang="ts">
@@ -21,11 +16,7 @@ const props = withDefaults(
   }
 )
 const containerWidth = defineModel<number>('containerWidth', { required: true })
-const { onResizeMouseDown, onResizeTouchStart } = useResize(
-  containerWidth,
-  props.minContainerWidth,
-  props.maxContainerWidth
-)
+const { onResizePointerDown } = useResize(containerWidth, props.minContainerWidth, props.maxContainerWidth)
 </script>
 
 <style lang="less" scoped>
@@ -36,6 +27,11 @@ const { onResizeMouseDown, onResizeTouchStart } = useResize(
   transition: background 0.2s;
   height: 100%;
   z-index: 10;
+  // 让浏览器把所有方向的拖动都交给我们处理，避免触屏滚动抢占事件
+  touch-action: none;
+  -ms-touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
   &:hover,
   &.active {
     background-color: var(--primary-color);

--- a/src/components/TorrentList/TorrentListHeader.vue
+++ b/src/components/TorrentList/TorrentListHeader.vue
@@ -37,10 +37,7 @@
         <div
           v-if="colIdx < visibleColumns.length"
           class="col-resizer"
-          @mousedown="onResizerMouseDown($event, col)"
-          @touchstart="onResizerTouchStart($event, col)"
-          @touchmove="onResizerTouchMove($event)"
-          @touchend="onResizerTouchEnd($event)"
+          @pointerdown="onResizerPointerDown($event, col)"
         ></div>
       </div>
     </div>
@@ -99,99 +96,61 @@ const showColumnMenu = defineModel<boolean>('showHeaderMenu', { default: false }
 const columnMenuX = ref(0)
 const columnMenuY = ref(0)
 
-function onResizerTouchStart(e: TouchEvent, col: { key: string; width: number }) {
+// 使用 Pointer Events 统一处理鼠标 / 触屏 / 触控笔，避免在
+// navigator.maxTouchPoints > 0 的混合设备上鼠标事件被误屏蔽
+function onResizerPointerDown(e: PointerEvent, col: { key: string; width: number }) {
+  if (e.button !== 0 && e.pointerType === 'mouse') {
+    return
+  }
   e.preventDefault()
   e.stopPropagation()
-  if (e.touches.length !== 1) {
-    return
-  }
-  const dom = e.target as HTMLElement
+  const dom = e.currentTarget as HTMLElement
   dom.classList.add('active')
-  resizing.value = true
-  resizeColKey.value = col.key
-  startX.value = e.touches[0].clientX
-  startWidth.value = col.width
-  if (headerRef.value) {
-    headerLeft.value = headerRef.value.getBoundingClientRect().left
-  } else {
-    headerLeft.value = 0
-  }
-  resizeLineX.value = e.touches[0].clientX - headerLeft.value
-  document.body.style.cursor = 'col-resize'
-}
-
-function onResizerTouchMove(e: TouchEvent) {
-  if (!resizing.value || e.touches.length !== 1) {
-    return
-  }
-  resizeLineX.value = e.touches[0].clientX - headerLeft.value
-  const touch = e.changedTouches[0]
-  const delta = touch.clientX - startX.value
-  const newWidth = Math.max(getMinWidth(resizeColKey.value), startWidth.value + delta)
-  if (resizeColKey.value) {
-    torrentStore.updateColumnWidth(resizeColKey.value, newWidth)
-  }
-}
-
-function onResizerTouchEnd(e: TouchEvent) {
-  if (!resizing.value) {
-    return
-  }
-  const dom = e.target as HTMLElement
-  dom.classList.remove('active')
-  const touch = e.changedTouches[0]
-  const delta = touch.clientX - startX.value
-  const newWidth = Math.max(getMinWidth(resizeColKey.value), startWidth.value + delta)
-  if (resizeColKey.value) {
-    torrentStore.updateColumnWidth(resizeColKey.value, newWidth)
-  }
-  resizing.value = false
-  resizeColKey.value = null
-  document.body.style.cursor = ''
-}
-
-function onResizerMouseDown(e: MouseEvent, col: { key: string; width: number }) {
   resizing.value = true
   resizeColKey.value = col.key
   startX.value = e.clientX
   startWidth.value = col.width
-  if (headerRef.value) {
-    headerLeft.value = headerRef.value.getBoundingClientRect().left
-  } else {
-    headerLeft.value = 0
-  }
+  headerLeft.value = headerRef.value ? headerRef.value.getBoundingClientRect().left : 0
   resizeLineX.value = e.clientX - headerLeft.value
   document.body.style.cursor = 'col-resize'
-  window.addEventListener('mousemove', onResizerMouseMove)
-  window.addEventListener('mouseup', onResizerMouseUp)
-}
 
-function onResizerMouseMove(e: MouseEvent) {
-  if (!resizing.value) {
-    return
+  const pointerId = e.pointerId
+  try {
+    dom.setPointerCapture(pointerId)
+  } catch {
+    // 忽略不支持的浏览器
   }
-  resizeLineX.value = e.clientX - headerLeft.value
-  const delta = e.clientX - startX.value
-  const newWidth = Math.max(getMinWidth(resizeColKey.value), startWidth.value + delta)
-  if (resizeColKey.value) {
-    torrentStore.updateColumnWidth(resizeColKey.value, newWidth)
-  }
-}
 
-function onResizerMouseUp(e: MouseEvent) {
-  if (!resizing.value) {
-    return
+  function onMove(evt: PointerEvent) {
+    if (!resizing.value || evt.pointerId !== pointerId) {
+      return
+    }
+    resizeLineX.value = evt.clientX - headerLeft.value
+    const delta = evt.clientX - startX.value
+    const newWidth = Math.max(getMinWidth(resizeColKey.value), startWidth.value + delta)
+    if (resizeColKey.value) {
+      torrentStore.updateColumnWidth(resizeColKey.value, newWidth)
+    }
   }
-  const delta = e.clientX - startX.value
-  const newWidth = Math.max(getMinWidth(resizeColKey.value), startWidth.value + delta)
-  if (resizeColKey.value) {
-    torrentStore.updateColumnWidth(resizeColKey.value, newWidth)
+
+  function cleanup() {
+    dom.classList.remove('active')
+    resizing.value = false
+    resizeColKey.value = null
+    document.body.style.cursor = ''
+    try {
+      dom.releasePointerCapture(pointerId)
+    } catch {
+      // 忽略
+    }
+    dom.removeEventListener('pointermove', onMove)
+    dom.removeEventListener('pointerup', cleanup)
+    dom.removeEventListener('pointercancel', cleanup)
   }
-  resizing.value = false
-  resizeColKey.value = null
-  document.body.style.cursor = ''
-  window.removeEventListener('mousemove', onResizerMouseMove)
-  window.removeEventListener('mouseup', onResizerMouseUp)
+
+  dom.addEventListener('pointermove', onMove)
+  dom.addEventListener('pointerup', cleanup)
+  dom.addEventListener('pointercancel', cleanup)
 }
 
 function onTableHeaderContextMenu(e: MouseEvent) {
@@ -277,6 +236,9 @@ function onCheckboxChange(checked: boolean) {
   z-index: 2;
   background: transparent;
   transition: background 0.2s;
+  // 让浏览器把所有方向的拖动都交给我们处理，避免触屏滚动抢占事件
+  touch-action: none;
+  -ms-touch-action: none;
   &:hover {
     background-color: var(--border-color);
   }

--- a/src/composables/useResize.ts
+++ b/src/composables/useResize.ts
@@ -1,41 +1,51 @@
-import { isSupportTouch } from '@/utils/evt'
-
 export function useResize(containerWidth: Ref<number>, minContainerWidth: number, maxContainerWidth: number) {
-  function handleResizeStart(startX: number, getCurrentX: (e: any) => number, moveEvent: string, upEvent: string) {
+  // 使用 Pointer Events 统一处理鼠标、触屏与触控笔
+  // 避免在 maxTouchPoints > 0 的混合设备上误判，导致鼠标无法拖动
+  function onResizePointerDown(e: PointerEvent) {
+    // 仅响应主按键（鼠标左键 / 触屏 / 笔）
+    if (e.button !== 0 && e.pointerType === 'mouse') {
+      return
+    }
+    e.preventDefault()
+    const dom = e.currentTarget as HTMLElement
+    const startX = e.clientX
     const startWidth = containerWidth.value ?? minContainerWidth
-    function onMove(e: any) {
-      const currentX = getCurrentX(e)
-      const newWidth = Math.max(minContainerWidth, Math.min(maxContainerWidth, startWidth + currentX - startX))
+    const pointerId = e.pointerId
+
+    // 锁定 pointer，确保拖出元素后仍能持续接收事件
+    try {
+      dom.setPointerCapture(pointerId)
+    } catch {
+      // 忽略不支持的浏览器
+    }
+    dom.classList.add('active')
+
+    function onMove(evt: PointerEvent) {
+      if (evt.pointerId !== pointerId) {
+        return
+      }
+      const newWidth = Math.max(minContainerWidth, Math.min(maxContainerWidth, startWidth + evt.clientX - startX))
       containerWidth.value = newWidth
     }
-    function onUp(e: any) {
-      const dom = e.target as HTMLElement
+
+    function cleanup() {
       dom.classList.remove('active')
-      window.removeEventListener(moveEvent, onMove)
-      window.removeEventListener(upEvent, onUp)
+      try {
+        dom.releasePointerCapture(pointerId)
+      } catch {
+        // 忽略不支持的浏览器
+      }
+      dom.removeEventListener('pointermove', onMove)
+      dom.removeEventListener('pointerup', cleanup)
+      dom.removeEventListener('pointercancel', cleanup)
     }
-    window.addEventListener(upEvent, onUp)
-    window.addEventListener(moveEvent, onMove)
+
+    dom.addEventListener('pointermove', onMove)
+    dom.addEventListener('pointerup', cleanup)
+    dom.addEventListener('pointercancel', cleanup)
   }
 
-  function onResizeMouseDown(e: MouseEvent) {
-    if (isSupportTouch) {
-      return
-    }
-    handleResizeStart(e.clientX, (evt) => evt.clientX, 'mousemove', 'mouseup')
-  }
-
-  function onResizeTouchStart(e: TouchEvent) {
-    if (e.touches.length !== 1) {
-      return
-    }
-    const dom = e.target as HTMLElement
-    dom.classList.add('active')
-    e.preventDefault()
-    handleResizeStart(e.touches[0].clientX, (evt) => evt.touches[0].clientX, 'touchmove', 'touchend')
-  }
   return {
-    onResizeMouseDown,
-    onResizeTouchStart
+    onResizePointerDown
   }
 }

--- a/src/composables/useVerticalResize.ts
+++ b/src/composables/useVerticalResize.ts
@@ -1,55 +1,54 @@
-import { isSupportTouch } from '@/utils/evt'
-
 export function useVerticalResize(
   containerHeight: Ref<number>,
   minContainerHeight: number,
   maxContainerHeight: number
 ) {
-  function handleResizeStart(
-    startY: number,
-    getCurrentY: (e: any) => number,
-    moveEvent: string,
-    upEvent: string,
-    target?: HTMLElement
-  ) {
-    const startHeight = containerHeight.value ?? minContainerHeight
-    if (target) {
-      target.classList.add('active')
+  // 使用 Pointer Events 统一处理鼠标、触屏与触控笔
+  // 避免在 maxTouchPoints > 0 的混合设备上误判，导致鼠标无法拖动
+  function onResizePointerDown(e: PointerEvent) {
+    if (e.button !== 0 && e.pointerType === 'mouse') {
+      return
     }
-    function onMove(e: any) {
-      const currentY = getCurrentY(e)
-      const delta = currentY - startY
+    e.preventDefault()
+    const dom = e.currentTarget as HTMLElement
+    const startY = e.clientY
+    const startHeight = containerHeight.value ?? minContainerHeight
+    const pointerId = e.pointerId
+
+    try {
+      dom.setPointerCapture(pointerId)
+    } catch {
+      // 忽略不支持的浏览器
+    }
+    dom.classList.add('active')
+
+    function onMove(evt: PointerEvent) {
+      if (evt.pointerId !== pointerId) {
+        return
+      }
+      const delta = evt.clientY - startY
       const newHeight = Math.max(minContainerHeight, Math.min(maxContainerHeight, startHeight - delta))
       containerHeight.value = newHeight
     }
-    function onUp() {
-      target?.classList.remove('active')
-      window.removeEventListener(moveEvent, onMove)
-      window.removeEventListener(upEvent, onUp)
-    }
-    window.addEventListener(upEvent, onUp)
-    window.addEventListener(moveEvent, onMove)
-  }
 
-  function onResizeMouseDown(e: MouseEvent) {
-    if (isSupportTouch) {
-      return
+    function cleanup() {
+      dom.classList.remove('active')
+      try {
+        dom.releasePointerCapture(pointerId)
+      } catch {
+        // 忽略不支持的浏览器
+      }
+      dom.removeEventListener('pointermove', onMove)
+      dom.removeEventListener('pointerup', cleanup)
+      dom.removeEventListener('pointercancel', cleanup)
     }
-    const dom = e.target as HTMLElement
-    handleResizeStart(e.clientY, (evt) => evt.clientY, 'mousemove', 'mouseup', dom)
-  }
 
-  function onResizeTouchStart(e: TouchEvent) {
-    if (e.touches.length !== 1) {
-      return
-    }
-    const dom = e.target as HTMLElement
-    e.preventDefault()
-    handleResizeStart(e.touches[0].clientY, (evt) => evt.touches[0].clientY, 'touchmove', 'touchend', dom)
+    dom.addEventListener('pointermove', onMove)
+    dom.addEventListener('pointerup', cleanup)
+    dom.addEventListener('pointercancel', cleanup)
   }
 
   return {
-    onResizeMouseDown,
-    onResizeTouchStart
+    onResizePointerDown
   }
 }


### PR DESCRIPTION
## Summary

修复 [#22](https://github.com/jianxcao/transmission-web/issues/22)：在飞牛 docker / 360 极速 X 等场景下，界面的边框无法拖动改变大小。

### 根因

`src/composables/useResize.ts` 与 `useVerticalResize.ts` 在 \`onMouseDown\` 入口加了如下守卫：

\`\`\`ts
if (isSupportTouch) {
  return
}
\`\`\`

而 \`isSupportTouch\` 的判定为：

\`\`\`ts
export const isSupportTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0
\`\`\`

很多现代 PC 浏览器（包括 360 极速 X 这类基于 Chromium 的浏览器，以及飞牛 NAS 上常用的浏览器）即便没有真正的触屏，也会上报 \`navigator.maxTouchPoints > 0\`。这导致鼠标按下事件被直接 \`return\`，**边框 / 列宽完全无法用鼠标拖动来改变大小**。

### 修复方案

统一改用 [Pointer Events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events)，一套代码同时支持鼠标、触屏与触控笔，避免再做容易误判的能力嗅探：

- \`useResize\` / \`useVerticalResize\` 重写为 \`pointerdown\` + \`setPointerCapture\` + \`pointermove\`/\`pointerup\`/\`pointercancel\`，移除 \`isSupportTouch\` 分支
- \`ResizeLine\` / \`ResizeHorizontalLine\` 模板改为 \`@pointerdown\`，并在拖拽手柄上加 \`touch-action: none\` 防止触屏滚动手势抢占指针事件
- \`TorrentListHeader\` 与 \`CanvasList/ListHeader\` 中原本 mouse / touch 两套列宽拖动逻辑（约 90 行重复代码）合并为单一 pointer 实现，行为一致且更简洁
- 通过 \`setPointerCapture\` 把整段拖动序列锁定到拖拽元素上，鼠标拖出窗口或快速划出元素也不会丢失事件

### 影响范围

- ✅ 桌面浏览器（包括 \`maxTouchPoints > 0\` 的混合设备）：现在可以正常用鼠标拖动
- ✅ 触屏设备：行为不变，仍可触屏拖动
- ✅ 触控笔：原本走 mouse 通路（取决于浏览器），现在统一走 pointer，行为更稳定
- 🧹 代码净减少约 70 行（删除重复 mouse/touch 实现）

## Test plan

- [x] \`pnpm check\`（vue-tsc 类型检查）通过
- [x] ESLint 检查通过
- [ ] 桌面 Chrome / Edge / Firefox：拖动主侧边栏边框、详情面板上边框、列表列宽 → 应可正常调整宽 / 高
- [ ] 触屏设备（iPad / Android）：触屏拖动同样可调整
- [ ] 飞牛 docker + 360 极速 X 场景（issue 报告环境）：原 bug 应已消失