### PR TITLE
feat(sidebar): 目录分布菜单支持按层级折叠并可在设置中切换模式

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -69,6 +69,8 @@ declare module 'vue' {
     NModalProvider: typeof import('naive-ui')['NModalProvider']
     NPopover: typeof import('naive-ui')['NPopover']
     NProgress: typeof import('naive-ui')['NProgress']
+    NRadioButton: typeof import('naive-ui')['NRadioButton']
+    NRadioGroup: typeof import('naive-ui')['NRadioGroup']
     NSelect: typeof import('naive-ui')['NSelect']
     NSpace: typeof import('naive-ui')['NSpace']
     NSpin: typeof import('naive-ui')['NSpin']

--- a/src/components/SiderbarView.vue/menus/DirMenu.vue
+++ b/src/components/SiderbarView.vue/menus/DirMenu.vue
@@ -8,22 +8,43 @@
 </template>
 <script setup lang="ts">
 import { useTorrentStore, useSettingStore } from '@/store'
+import type { IDirMenuOption } from '@/store/torrentUtils'
 import { renderIcon } from '@/utils'
-import { FileTray, Folder } from '@vicons/ionicons5'
+import { FileTray, Folder, ShuffleOutline } from '@vicons/ionicons5'
+import type { MenuOption } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 const torrentStore = useTorrentStore()
 const settingStore = useSettingStore()
 const { t: $t } = useI18n()
-const dirMenuOptions = computed(() => {
+
+// 递归地把目录树节点转成 n-menu 选项，并补上图标
+const decorate = (option: IDirMenuOption): MenuOption => {
+  const menuOption: MenuOption = {
+    key: option.key,
+    label: option.label,
+    icon: renderIcon(Folder)
+  }
+  if (option.children && option.children.length > 0) {
+    menuOption.children = option.children.map(decorate)
+  }
+  return menuOption
+}
+
+const dirMenuOptions = computed<MenuOption[]>(() => {
+  const total = torrentStore.torrents.length
   return [
     {
       label: $t('sidebar.directory'),
       key: 'dir',
       icon: renderIcon(FileTray),
-      children: torrentStore.downloadDirOptions.map((item) => ({
-        ...item,
-        icon: renderIcon(item.icon || Folder)
-      }))
+      children: [
+        {
+          key: 'all',
+          label: $t('common.all', { total }),
+          icon: renderIcon(ShuffleOutline)
+        },
+        ...torrentStore.downloadDirMenuOptions.map(decorate)
+      ]
     }
   ]
 })

--- a/src/components/dialog/settings/OtherSettings.vue
+++ b/src/components/dialog/settings/OtherSettings.vue
@@ -6,6 +6,15 @@
       <n-form-item :label="$t('otherSettings.singleLine')">
         <n-switch v-model:value="form['single-line']" />
       </n-form-item>
+      <n-form-item :label="$t('otherSettings.dirMenuMode')">
+        <n-radio-group v-model:value="form['dir-menu-mode']">
+          <n-radio-button value="list">{{ $t('otherSettings.dirMenuModeList') }}</n-radio-button>
+          <n-radio-button value="tree">{{ $t('otherSettings.dirMenuModeTree') }}</n-radio-button>
+        </n-radio-group>
+        <n-text depth="3" style="font-size: 12px; margin-left: 8px">
+          {{ $t('otherSettings.dirMenuModeHint') }}
+        </n-text>
+      </n-form-item>
       <n-form-item>
         <template #label>
           <n-checkbox v-model:checked="form['script-torrent-done-enabled']">{{

--- a/src/components/dialog/settings/SettingsContent.vue
+++ b/src/components/dialog/settings/SettingsContent.vue
@@ -167,6 +167,7 @@ const formInit = () => {
   sessionForm.value['script-torrent-done-filename'] = session.value?.['script-torrent-done-filename'] || ''
   sessionForm.value['script-torrent-done-enabled'] = !!session.value?.['script-torrent-done-enabled']
   sessionForm.value['single-line'] = !!settingStore.setting.singleLine
+  sessionForm.value['dir-menu-mode'] = settingStore.setting.dirMenuMode || 'list'
   sessionForm.value['default-trackers'] =
     session.value?.['default-trackers'] || settingStore.setting.defaultTrackers.join('\n')
 }
@@ -190,7 +191,11 @@ async function onSave() {
       settingStore.setPolling(pollingForm.value)
     }
     settingStore.setting.singleLine = !!sessionForm.value['single-line']
-    await rpc.sessionSet(omit(sessionForm.value, ['single-line']))
+    const dirMenuMode = sessionForm.value['dir-menu-mode']
+    if (dirMenuMode === 'tree' || dirMenuMode === 'list') {
+      settingStore.setting.dirMenuMode = dirMenuMode
+    }
+    await rpc.sessionSet(omit(sessionForm.value, ['single-line', 'dir-menu-mode']))
     message.success($t('settings.saveSuccess'))
     emit('save-success')
   } catch {

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -244,6 +244,10 @@
   "otherSettings": {
     "title": "Other Settings",
     "singleLine": "Single Line Display",
+    "dirMenuMode": "Directory Menu Mode",
+    "dirMenuModeList": "List",
+    "dirMenuModeTree": "Tree",
+    "dirMenuModeHint": "List: flat view of all download directories. Tree: collapse by levels and expand subdirectories manually.",
     "enableScript": "Enable Torrent Completion Script",
     "scriptPlaceholder": "Whether to enable torrent completion script",
     "defaultTrackers": "Default Tracker List",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -244,6 +244,10 @@
   "otherSettings": {
     "title": "其他设置",
     "singleLine": "单行显示",
+    "dirMenuMode": "目录菜单展示模式",
+    "dirMenuModeList": "列表",
+    "dirMenuModeTree": "目录",
+    "dirMenuModeHint": "列表：扁平展示所有下载目录；目录：按层级折叠，可手动展开子目录。",
     "enableScript": "启用种子完成脚本",
     "scriptPlaceholder": "是否启用种子完成脚本",
     "defaultTrackers": "默认tracker列表",

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -50,6 +50,8 @@ export const useSettingStore = defineStore('setting', () => {
         torrentInterval: 5
       },
       menuExpandedKeys: ['status', 'labels', 'dir'],
+      // 目录侧边栏展示模式：list = 扁平展示所有目录；tree = 按层级折叠
+      dirMenuMode: 'list' as 'list' | 'tree',
       // 忽略域名中的部分前缀
       ignoredTrackerPrefixes: ['t', 'tr', 'tk', 'tracker', 'bt', 'open', 'opentracker', 'pt']
     },

--- a/src/store/torrent.ts
+++ b/src/store/torrent.ts
@@ -6,6 +6,8 @@ import { useSettingStore } from '@/store/setting'
 import { defineStore } from 'pinia'
 import { computed, ref, watch } from 'vue'
 import {
+  buildDirMenuList,
+  buildDirMenuTree,
   detailFilterOptions,
   isFilterTorrents,
   mapToOptions,
@@ -130,6 +132,9 @@ export const useTorrentStore = defineStore('torrent', () => {
     const mapFilterTorrentsIndex: Record<number, number> = {}
     const mapTorrentsIndex: Record<number, number> = {}
 
+    // 目录菜单当前模式（read once，使其参与依赖收集）
+    const dirMenuMode = settingStore.setting.dirMenuMode
+
     // 一次循环完成所有计算：统计 + 过滤
     let filteredIndex = 0
     torrents.value.forEach((t, idx) => {
@@ -138,7 +143,16 @@ export const useTorrentStore = defineStore('torrent', () => {
       detailFilterOptions(t, labelsSet, trackerSet, errorStringSet, downloadDirSet, statusSet)
       // 如果通过所有过滤条件，加入结果数组
       if (
-        isFilterTorrents(t, search, statusFilter, labelsFilter, trackerFilter, errorStringFilter, downloadDirFilter)
+        isFilterTorrents(
+          t,
+          search,
+          statusFilter,
+          labelsFilter,
+          trackerFilter,
+          errorStringFilter,
+          downloadDirFilter,
+          dirMenuMode
+        )
       ) {
         filtered.push(t)
         mapFilterTorrentsIndex[t.id] = filteredIndex++
@@ -162,7 +176,10 @@ export const useTorrentStore = defineStore('torrent', () => {
     if (!errorStringSet.get(errorStringFilter.value)) {
       errorStringFilter.value = 'all'
     }
-    if (!downloadDirSet.get(downloadDirFilter.value)) {
+    // 根据用户配置生成目录菜单：扁平 (list) 或 树形 (tree)
+    // validKeys 用于校验当前过滤值是否仍然有效（数据/模式变化后失效则重置）
+    const dirMenu = dirMenuMode === 'tree' ? buildDirMenuTree(downloadDirSet) : buildDirMenuList(downloadDirSet)
+    if (!dirMenu.validKeys.has(downloadDirFilter.value)) {
       downloadDirFilter.value = 'all'
     }
     const options = {
@@ -170,6 +187,7 @@ export const useTorrentStore = defineStore('torrent', () => {
       trackerOptions: mapToOptions(trackerSet, torrents.value.length),
       errorStringOptions: mapToOptions(errorStringSet, torrents.value.length),
       downloadDirOptions: mapToOptions(downloadDirSet, torrents.value.length),
+      downloadDirMenuOptions: dirMenu.options,
       statusOptions: mapToOptions(statusSet, torrents.value.length)
     }
     return {
@@ -258,6 +276,7 @@ export const useTorrentStore = defineStore('torrent', () => {
     trackerOptions: computed(() => options.value.trackerOptions),
     errorStringOptions: computed(() => options.value.errorStringOptions),
     downloadDirOptions: computed(() => options.value.downloadDirOptions),
+    downloadDirMenuOptions: computed(() => options.value.downloadDirMenuOptions),
     statusOptions: computed(() => options.value.statusOptions),
     fetchTorrents,
     mapSelectedKeys,

--- a/src/store/torrentUtils.ts
+++ b/src/store/torrentUtils.ts
@@ -124,8 +124,12 @@ const lastSegmentOf = (path: string): string => {
 }
 
 // 将扁平的下载目录集合按 `/` 切分构建成树形菜单
-// - 单子节点链路自动合并显示（如 /home/user/downloads 不会逐级展示）
-// - 父节点的数量为自身和所有后代的累计
+// - 严格按真实层级展开，每一级目录都是单独的可点击/可折叠节点
+//   （即使该层级只有一个子节点也不合并，符合「先出来一级，再手动点开
+//    二级、三级」的诉求）
+// - 父节点数量为自身 + 所有后代的累计
+// - 绝对路径前导 `/` 产生的空根节点自动跳过，其子节点直接作为顶层项
+//   （并在 label 上保留 `/` 作为视觉提示）
 // - 同时返回 validKeys 集合，便于校验当前过滤值是否还有效
 export const buildDirMenuTree = (
   downloadDirSet: Map<string, IMenuItem>
@@ -171,27 +175,29 @@ export const buildDirMenuTree = (
 
   const validKeys = new Set<string>(['all'])
 
-  // 递归转换成 n-menu 选项，遇到「单子节点 + 自身无 count」的链路就合并
-  const toOption = (node: ITreeNode): IDirMenuOption => {
-    let cur = node
-    const labelParts: string[] = [lastSegmentOf(cur.fullPath)]
-    while (cur.children.size === 1 && cur.count === 0) {
-      const onlyChild = cur.children.values().next().value as ITreeNode
-      cur = onlyChild
-      labelParts.push(lastSegmentOf(cur.fullPath))
+  // 计算节点相对父节点的 label：
+  // - 如果父节点是空根（绝对路径根），label 直接用 fullPath（带前导 `/`）
+  // - 否则只取末段 segment
+  // - 兜底：fullPath 为空（极端情况）回退为 `/`
+  const computeSegment = (fullPath: string, parentPath: string): string => {
+    if (parentPath === '' && fullPath !== '') {
+      return fullPath
     }
-    const segment = labelParts.join('/')
-    // 兜底：根节点 path 为空时，segment 也为空，使用 fullPath
-    const display = segment || cur.fullPath || '/'
-    validKeys.add(cur.fullPath)
+    return lastSegmentOf(fullPath) || fullPath || '/'
+  }
+
+  // 递归转换成 n-menu 选项；parentPath 是上一级真实显示出来的节点 path
+  const toOption = (node: ITreeNode, parentPath: string): IDirMenuOption => {
+    validKeys.add(node.fullPath)
+    const segment = computeSegment(node.fullPath, parentPath)
     const children: IDirMenuOption[] = []
-    for (const child of cur.children.values()) {
-      children.push(toOption(child))
+    for (const child of node.children.values()) {
+      children.push(toOption(child, node.fullPath))
     }
     const result: IDirMenuOption = {
-      key: cur.fullPath,
-      label: `${display}（${cur.totalCount}）`,
-      count: cur.totalCount
+      key: node.fullPath,
+      label: `${segment}（${node.totalCount}）`,
+      count: node.totalCount
     }
     if (children.length > 0) {
       result.children = children
@@ -201,7 +207,14 @@ export const buildDirMenuTree = (
 
   const options: IDirMenuOption[] = []
   for (const child of root.children.values()) {
-    options.push(toOption(child))
+    // 跳过绝对路径前导 `/` 形成的空根节点，把它的子节点直接提到顶层
+    if (child.fullPath === '' && child.count === 0 && child.children.size > 0) {
+      for (const grandchild of child.children.values()) {
+        options.push(toOption(grandchild, ''))
+      }
+    } else {
+      options.push(toOption(child, ''))
+    }
   }
 
   return { options, validKeys }

--- a/src/store/torrentUtils.ts
+++ b/src/store/torrentUtils.ts
@@ -107,6 +107,123 @@ export const mapToOptions = (map: Map<string, IMenuItem>, total: number) => {
   ]
 }
 
+// 目录菜单选项（树形结构）
+export interface IDirMenuOption {
+  key: string
+  label: string
+  count: number
+  children?: IDirMenuOption[]
+}
+
+const lastSegmentOf = (path: string): string => {
+  if (!path) {
+    return ''
+  }
+  const idx = path.lastIndexOf('/')
+  return idx < 0 ? path : path.substring(idx + 1)
+}
+
+// 将扁平的下载目录集合按 `/` 切分构建成树形菜单
+// - 单子节点链路自动合并显示（如 /home/user/downloads 不会逐级展示）
+// - 父节点的数量为自身和所有后代的累计
+// - 同时返回 validKeys 集合，便于校验当前过滤值是否还有效
+export const buildDirMenuTree = (
+  downloadDirSet: Map<string, IMenuItem>
+): { options: IDirMenuOption[]; validKeys: Set<string> } => {
+  interface ITreeNode {
+    fullPath: string
+    count: number
+    totalCount: number
+    children: Map<string, ITreeNode>
+  }
+
+  const root: ITreeNode = { fullPath: '', count: 0, totalCount: 0, children: new Map() }
+
+  for (const [dir, item] of downloadDirSet.entries()) {
+    // 去掉末尾的多余斜杠，保证路径统一
+    const normalized = dir.replace(/\/+$/, '')
+    const parts = normalized.split('/')
+    let cumPath = ''
+    let curNode = root
+    for (let i = 0; i < parts.length; i++) {
+      cumPath = i === 0 ? parts[i] : `${cumPath}/${parts[i]}`
+      let child = curNode.children.get(cumPath)
+      if (!child) {
+        child = { fullPath: cumPath, count: 0, totalCount: 0, children: new Map() }
+        curNode.children.set(cumPath, child)
+      }
+      curNode = child
+    }
+    // 累加 count，避免不同路径归一化后冲突时丢数据
+    curNode.count += item.count
+  }
+
+  // DFS 计算累计数量
+  const computeTotal = (node: ITreeNode): number => {
+    let total = node.count
+    for (const child of node.children.values()) {
+      total += computeTotal(child)
+    }
+    node.totalCount = total
+    return total
+  }
+  computeTotal(root)
+
+  const validKeys = new Set<string>(['all'])
+
+  // 递归转换成 n-menu 选项，遇到「单子节点 + 自身无 count」的链路就合并
+  const toOption = (node: ITreeNode): IDirMenuOption => {
+    let cur = node
+    const labelParts: string[] = [lastSegmentOf(cur.fullPath)]
+    while (cur.children.size === 1 && cur.count === 0) {
+      const onlyChild = cur.children.values().next().value as ITreeNode
+      cur = onlyChild
+      labelParts.push(lastSegmentOf(cur.fullPath))
+    }
+    const segment = labelParts.join('/')
+    // 兜底：根节点 path 为空时，segment 也为空，使用 fullPath
+    const display = segment || cur.fullPath || '/'
+    validKeys.add(cur.fullPath)
+    const children: IDirMenuOption[] = []
+    for (const child of cur.children.values()) {
+      children.push(toOption(child))
+    }
+    const result: IDirMenuOption = {
+      key: cur.fullPath,
+      label: `${display}（${cur.totalCount}）`,
+      count: cur.totalCount
+    }
+    if (children.length > 0) {
+      result.children = children
+    }
+    return result
+  }
+
+  const options: IDirMenuOption[] = []
+  for (const child of root.children.values()) {
+    options.push(toOption(child))
+  }
+
+  return { options, validKeys }
+}
+
+// 扁平的目录菜单（保留原有交互），用于和树形菜单对应统一的数据结构
+export const buildDirMenuList = (
+  downloadDirSet: Map<string, IMenuItem>
+): { options: IDirMenuOption[]; validKeys: Set<string> } => {
+  const validKeys = new Set<string>(['all'])
+  const options: IDirMenuOption[] = []
+  for (const [dir, item] of downloadDirSet.entries()) {
+    validKeys.add(dir)
+    options.push({
+      key: dir,
+      label: `${dir}（${item.count}）`,
+      count: item.count
+    })
+  }
+  return { options, validKeys }
+}
+
 const normalizeTorrentSearchText = (value: string) => value.toLocaleLowerCase().replace(/[^\p{L}\p{N}]+/gu, '')
 
 // 是否可以过滤这个种子
@@ -117,7 +234,8 @@ export const isFilterTorrents = function (
   labelsFilter: globalThis.Ref<string, string>,
   trackerFilter: globalThis.Ref<string, string>,
   errorStringFilter: globalThis.Ref<string, string>,
-  downloadDirFilter: globalThis.Ref<string, string>
+  downloadDirFilter: globalThis.Ref<string, string>,
+  dirMenuMode: 'list' | 'tree' = 'list'
 ) {
   // === 2. 同时进行过滤判断 ===
   let shouldInclude = true
@@ -171,13 +289,18 @@ export const isFilterTorrents = function (
   }
 
   // 下载目录过滤
-  if (
-    shouldInclude &&
-    downloadDirFilter.value &&
-    downloadDirFilter.value !== 'all' &&
-    t.downloadDir !== downloadDirFilter.value
-  ) {
-    shouldInclude = false
+  // - tree 模式：前缀匹配（父目录可筛出其下所有子目录的种子）
+  // - list 模式：精确匹配（保留原始扁平菜单的语义）
+  if (shouldInclude && downloadDirFilter.value && downloadDirFilter.value !== 'all') {
+    const filterPath = downloadDirFilter.value
+    const torrentDir = t.downloadDir
+    if (dirMenuMode === 'tree') {
+      if (torrentDir !== filterPath && !torrentDir.startsWith(`${filterPath}/`)) {
+        shouldInclude = false
+      }
+    } else if (torrentDir !== filterPath) {
+      shouldInclude = false
+    }
   }
 
   return shouldInclude


### PR DESCRIPTION
## 背景

参见 #20，希望"目录分布"侧边栏对目录较多的用户更友好——能像树一样按层级折叠，而不是一次性铺平展示。但同时不能影响习惯了扁平列表的用户，因此把它做成一个可切换的设置项。

## Summary

- 新增"目录菜单展示模式"设置项（其他设置 → Other Settings）：
  - `list`：扁平展示所有下载目录，过滤为**精确匹配**（保留旧行为）
  - `tree`：按 `/` 分级构建目录树，**自动合并单子节点链路**（避免 `/home`→`/home/user`→`/home/user/downloads` 这种逐级点开），父节点显示子树累计数量；点父目录使用**前缀匹配**筛出其下所有子目录的种子
- 默认值 `list`，老用户无感升级；用户在「设置 → 其他设置」可切换
- 默认仅展开顶层 `dir` 节点，子目录由用户手动展开（与 issue 中的诉求一致）；展开状态会持久化到 `settingStore.menuExpandedKeys`

## 主要改动

| 文件 | 变更 |
|------|------|
| `src/store/torrentUtils.ts` | 新增 `buildDirMenuTree` / `buildDirMenuList`，返回统一的 `IDirMenuOption[]` + `validKeys`；`isFilterTorrents` 增加 `dirMenuMode` 参数按模式选择前缀或精确匹配 |
| `src/store/torrent.ts` | 根据 `settingStore.setting.dirMenuMode` 选择菜单生成器，并使用 `validKeys` 校验当前过滤值是否仍然有效（数据/模式变化后失效则自动重置为 `all`） |
| `src/store/setting.ts` | 新增默认值 `dirMenuMode: 'list'` |
| `src/components/SiderbarView.vue/menus/DirMenu.vue` | 递归渲染目录菜单并补齐 `Folder` 图标 |
| `src/components/dialog/settings/OtherSettings.vue` | 新增 `n-radio-group` 切换控件 |
| `src/components/dialog/settings/SettingsContent.vue` | 接入初始化与保存逻辑（保存时从 `sessionForm` 同步到 `settingStore`，并从 RPC payload 中剔除该字段） |
| `src/i18n/locales/{zh-CN,en-US}.json` | 补全 `otherSettings.dirMenuMode*` 文案 |
| `components.d.ts` | `unplugin-vue-components` 自动产物：新增 `NRadioGroup` / `NRadioButton` |

## 默认行为兼容性

- 默认值是 `list`，所有现有用户首次升级后看到的目录菜单与升级前完全一致
- 模式切换在 store 中通过 `validKeys.has(filter)` 校验当前过滤值，**任意时刻切换都不会出现"选了一个无效目录导致空列表"的情况**——失效自动回退到 `all`

## Test plan

- [ ] 默认状态（list 模式）：侧边栏目录列表与改动前完全一致；点击具体目录精确过滤
- [ ] 在「设置 → 其他设置 → 目录菜单展示模式」切换为 `tree`，保存后：
  - [ ] 菜单变成层级树，单子节点链路被自动合并
  - [ ] 默认仅展开 `dir` 顶层，子目录需手动展开
  - [ ] 点击父级目录可前缀匹配，筛出其下所有子目录的种子
  - [ ] 父级目录显示的数量等于自身 + 全部后代累计
- [ ] 切回 `list`：菜单恢复扁平，过滤仍按精确匹配工作
- [ ] 移除/新增种子使某个被选中的目录消失时，过滤值自动重置为 `all`
- [ ] 中英文切换文案正确

Closes #20