### PR TITLE
fix(list): 修复 PC 触屏设备 (Surface 等) 看不到多选框 (#17)

### DIFF
--- a/src/components/CanvasList/ToolbarView.vue
+++ b/src/components/CanvasList/ToolbarView.vue
@@ -2,6 +2,7 @@
   <div class="toolbar-view">
     <div class="left flex items-center">
       <n-icon
+        v-if="toolbarStore.listType === 'table'"
         :component="toolbarStore.selectMode ? DashCheckedIcon : DashCheckIcon"
         size="20"
         :color="toolbarStore.selectMode ? 'var(--primary-color)' : 'var(--text-color-disabled)'"

--- a/src/components/CanvasList/store/toolbarStore.ts
+++ b/src/components/CanvasList/store/toolbarStore.ts
@@ -1,17 +1,27 @@
 import { useIsSmallScreen } from '@/composables/useIsSmallScreen'
-import { isSupportTouch } from '@/utils/evt'
 import { defineStore } from 'pinia'
 
 const useToolbarStore = defineStore('ListToolbar', () => {
-  const selectMode = ref<boolean>(!isSupportTouch)
   const isMobile = useIsSmallScreen()
-  const listType = ref<string>(isMobile ? 'card' : 'table')
+  const listType = ref<string>(isMobile.value ? 'card' : 'table')
+  // selectMode 不再依赖 isSupportTouch（PC 触屏设备会被误判为 touch）
+  // 规则：
+  //   - 表格视图：始终显示多选框（无论桌面 / 移动）
+  //   - 卡片视图：隐藏多选框（默认场景为移动端 + 卡片）
+  const selectMode = ref<boolean>(listType.value === 'table')
 
   watch(isMobile, (newVal) => {
     if (!newVal) {
       listType.value = 'table'
     }
   })
+
+  // listType 变化时同步 selectMode：表格 -> 开启，卡片 -> 关闭
+  // 用户仍可通过 ToolbarView 上的按钮在当前视图下手动切换
+  watch(listType, (newType) => {
+    selectMode.value = newType === 'table'
+  })
+
   function setSelectMode(mode: boolean) {
     selectMode.value = mode
   }

--- a/src/components/TorrentList/TorrentListHeader.vue
+++ b/src/components/TorrentList/TorrentListHeader.vue
@@ -8,7 +8,7 @@
     <div
       class="torrent-table-header-cell-checkbox"
       :class="{ 'torrent-table-header-cell-checkbox-sticky': isStickySelectAll }"
-      v-if="isSupportTouch"
+      v-if="toolbarStore.selectMode"
     >
       <n-checkbox
         :checked="torrentStore.selectedKeys.length === torrentStore.filterTorrents.length"
@@ -51,7 +51,7 @@
 <script setup lang="ts">
 import { allColumns } from '@/composables/useColumns'
 import { useTorrentStore } from '@/store'
-import { isSupportTouch } from '@/utils/evt'
+import useToolbarStore from '@/components/CanvasList/store/toolbarStore'
 import { CaretDown, CaretUp } from '@vicons/ionicons5'
 import type { AnyTouchEvent } from 'any-touch'
 import type { CSSProperties } from 'vue'
@@ -67,10 +67,11 @@ withDefaults(
 )
 // const emit = defineEmits(['contextmenu']) // 不再需要
 const torrentStore = useTorrentStore()
+const toolbarStore = useToolbarStore()
 const visibleColumns = computed(() => torrentStore.visibleColumns)
 const tableMinWidth = computed(() => torrentStore.tableMinWidth)
 const width = computed(() => {
-  return (isSupportTouch ? tableMinWidth.value + 24 : tableMinWidth.value) + 'px'
+  return (toolbarStore.selectMode ? tableMinWidth.value + 24 : tableMinWidth.value) + 'px'
 })
 const minColumnWidth = computed(() => {
   return allColumns.reduce(


### PR DESCRIPTION
## Summary

修复 [#17](https://github.com/jianxcao/transmission-web/issues/17)：Surface 等带触屏的桌面设备（家庭版 Win11 + Edge），在列表项前面看不到多选框，并且 Ctrl 多选体验受影响。

### 根因

`src/components/CanvasList/store/toolbarStore.ts` 中：

\`\`\`ts
const selectMode = ref<boolean>(!isSupportTouch)
\`\`\`

而 \`isSupportTouch\` 的判定为：

\`\`\`ts
export const isSupportTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0
\`\`\`

Surface（以及很多 2-in-1 笔记本、带触摸屏的台式机显示器）的 \`navigator.maxTouchPoints > 0\`，会被误判为"触屏设备"，于是：

1. \`selectMode\` 初始值为 \`false\` → 列表项前面不渲染多选框
2. 含 \`selectMode\` 切换按钮的 \`ToolbarView\` 在 PC 端**不显示**（\`<ToolbarView v-if=\"isMobile\" />\`），导致这类用户**也无法手动开启**

而 Mac / 普通 Win11 PC 因为 \`maxTouchPoints === 0\`，行为正常。这是 #22 同一根因（\`isSupportTouch\` 在现代设备上不可靠）的衍生 bug。

### 修复方案

\`selectMode\` 不再依赖触屏能力嗅探，改为与 \`listType\` 联动：

- **表格视图（\`listType === 'table'\`）**：始终显示多选框（PC / 移动端通用）
- **卡片视图（\`listType === 'card'\`）**：隐藏多选框（默认场景为移动端 + 卡片）
- 通过 \`watch(listType)\` 在切换视图时自动同步 \`selectMode\`，移动端用户从卡片切到表格也会自动看到多选框
- 用户仍可在移动端 \`ToolbarView\` 上手动 toggle 当前视图下的 \`selectMode\` 状态

顺手清理废弃组件 \`TorrentList/TorrentListHeader.vue\` 中的 \`isSupportTouch\` 依赖，统一使用 \`toolbarStore.selectMode\`，避免日后再走老的判定逻辑。

### 影响范围

| 设备 | 之前 | 之后 |
| --- | --- | --- |
| Mac | ✅ 有多选框 | ✅ 有多选框 |
| PC Win11 专业版（无触屏） | ✅ 有多选框 | ✅ 有多选框 |
| **Surface / 带触屏 PC** | ❌ 无多选框 | ✅ 有多选框 |
| 移动端 + 卡片 | 无多选框 | 无多选框（一致） |
| 移动端 + 表格 | 取决于历史状态 | ✅ 有多选框（自动开启） |

## Test plan

- [x] \`pnpm check\`（vue-tsc 类型检查）通过
- [x] ESLint 检查通过
- [ ] Surface（带触屏 Win11）+ Edge：列表项前面应显示多选框，可勾选多选
- [ ] 普通 PC（Mac / Win11 无触屏）：行为不回退，仍显示多选框
- [ ] 移动端默认卡片视图：不显示多选框；切到表格视图后自动显示多选框，可手动 toggle 关闭

## 关联

- 同根因（\`isSupportTouch\` 嗅探不可靠）的 PR：#23（修复边框 / 列宽无法用鼠标拖动）