### PR TITLE
fix: 修复校验进度展示与排序，并新增等待做种筛选

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist
 .env.local
 .secrets
 dev-dist
+.idea
+.env.development

--- a/src/components/CanvasList/MobileCells/ProgressStatusCell.ts
+++ b/src/components/CanvasList/MobileCells/ProgressStatusCell.ts
@@ -1,9 +1,10 @@
-import { getStatusString, Status } from '@/types/tr'
+import { getStatusString } from '@/types/tr'
 import type { ThemeCommonVars } from 'naive-ui'
 import { fitText, getTextWidth, roundRect } from '../cells/utils'
 import { MOBILE_LINE_MARGIN, MOBILE_PROGRESS_HEIGHT } from '../store/mobileUtils'
 import type { MobileCellComponent, MobileCellHeightCalculator, MobileCellRenderer } from './types'
 import { rowDark } from 'naive-ui/es/legacy-grid/styles'
+import { getTorrentProgress } from '@/utils/torrentProgress'
 
 // 获取状态颜色和背景色
 function getStatusColors(
@@ -162,11 +163,7 @@ const render: MobileCellRenderer = ({ ctx, row, state, theme }) => {
   const progressBarX = state.x
   const progressTextX = state.x + progressBarWidth
   const statusTagX = state.x + progressBarWidth + progressTextWidth
-  // 等待校验/校验中时展示校验进度 recheckProgress，否则用下载进度 percentDone
-  const percentDone =
-    row.status === Status.queuedToVerify || row.status === Status.verifying
-      ? Math.min(Math.max(Number(row.recheckProgress) || 0, 0), 1)
-      : Math.min(Math.max(row.percentDone, 0), 1)
+  const percentDone = getTorrentProgress(row)
 
   // 绘制进度条
   drawProgressBar(

--- a/src/components/CanvasList/MobileCells/ProgressStatusCell.ts
+++ b/src/components/CanvasList/MobileCells/ProgressStatusCell.ts
@@ -1,4 +1,4 @@
-import { getStatusString } from '@/types/tr'
+import { getStatusString, Status } from '@/types/tr'
 import type { ThemeCommonVars } from 'naive-ui'
 import { fitText, getTextWidth, roundRect } from '../cells/utils'
 import { MOBILE_LINE_MARGIN, MOBILE_PROGRESS_HEIGHT } from '../store/mobileUtils'
@@ -162,8 +162,11 @@ const render: MobileCellRenderer = ({ ctx, row, state, theme }) => {
   const progressBarX = state.x
   const progressTextX = state.x + progressBarWidth
   const statusTagX = state.x + progressBarWidth + progressTextWidth
-  // 限制 percentDone 在 0-1 范围内
-  const percentDone = Math.min(Math.max(row.percentDone, 0), 1)
+  // 等待校验/校验中时展示校验进度 recheckProgress，否则用下载进度 percentDone
+  const percentDone =
+    row.status === Status.queuedToVerify || row.status === Status.verifying
+      ? Math.min(Math.max(Number(row.recheckProgress) || 0, 0), 1)
+      : Math.min(Math.max(row.percentDone, 0), 1)
 
   // 绘制进度条
   drawProgressBar(

--- a/src/components/CanvasList/cells/PercentBarCell.ts
+++ b/src/components/CanvasList/cells/PercentBarCell.ts
@@ -3,7 +3,7 @@ import type { ColumnConfig } from '@/composables/useColumns'
 import { PADDING_X } from '../store/utils'
 import { roundRect, roundRectLeft } from './utils'
 import { useSettingStore } from '@/store'
-import { Status } from '@/types/tr'
+import { getTorrentProgress } from '@/utils/torrentProgress'
 
 export default function renderPercentBarCell(
   ctx: CanvasRenderingContext2D,
@@ -19,21 +19,7 @@ export default function renderPercentBarCell(
   const barRadius = height / 3
   const barX = x + PADDING_X
   const barY = y + (rowHeight - height) / 2
-  // 等待校验/校验中时展示校验进度 recheckProgress，否则用下载进度 percentDone
-  let percent: number
-  if (row.status === Status.queuedToVerify || row.status === Status.verifying) {
-    percent = Math.round((Number(row.recheckProgress) || 0) * 100)
-  } else {
-    // 目前 返回的数据中percentDone在下载的时候一直是 0
-    const value = Number(row[col.key as keyof Torrent])
-    percent = Math.round(value * 100)
-    const sizeWhenDone = Number(row.sizeWhenDone)
-    const downloadedEver = Number(row.downloadedEver)
-    if (downloadedEver > 0) {
-      percent = Math.max(percent, Math.min(Math.round((downloadedEver / sizeWhenDone) * 100), 100))
-    }
-  }
-  percent = Math.min(Math.max(percent, 0), 100)
+  const percent = Math.round(getTorrentProgress(row) * 100)
   const percentWidth = Math.max((width * percent) / 100, 0)
   const active = row.rateDownload > 0 || row.rateUpload > 0
   const theme = settingStore.themeVars

--- a/src/components/CanvasList/cells/PercentBarCell.ts
+++ b/src/components/CanvasList/cells/PercentBarCell.ts
@@ -3,6 +3,7 @@ import type { ColumnConfig } from '@/composables/useColumns'
 import { PADDING_X } from '../store/utils'
 import { roundRect, roundRectLeft } from './utils'
 import { useSettingStore } from '@/store'
+import { Status } from '@/types/tr'
 
 export default function renderPercentBarCell(
   ctx: CanvasRenderingContext2D,
@@ -12,19 +13,25 @@ export default function renderPercentBarCell(
 ) {
   ctx.save()
   const settingStore = useSettingStore()
-  const value = Number(row[col.key as keyof Torrent])
   const { x, y, rowHeight } = state
   const width = col.width - PADDING_X * 2
   const height = Math.min(22, rowHeight - 4)
   const barRadius = height / 3
   const barX = x + PADDING_X
   const barY = y + (rowHeight - height) / 2
-  let percent = Math.round(value * 100)
-  // 目前 返回的数据中percentDone在下载的时候一直是 0
-  const sizeWhenDone = Number(row.sizeWhenDone)
-  const downloadedEver = Number(row.downloadedEver)
-  if (downloadedEver > 0) {
-    percent = Math.max(percent, Math.min(Math.round((downloadedEver / sizeWhenDone) * 100), 100))
+  // 等待校验/校验中时展示校验进度 recheckProgress，否则用下载进度 percentDone
+  let percent: number
+  if (row.status === Status.queuedToVerify || row.status === Status.verifying) {
+    percent = Math.round((Number(row.recheckProgress) || 0) * 100)
+  } else {
+    // 目前 返回的数据中percentDone在下载的时候一直是 0
+    const value = Number(row[col.key as keyof Torrent])
+    percent = Math.round(value * 100)
+    const sizeWhenDone = Number(row.sizeWhenDone)
+    const downloadedEver = Number(row.downloadedEver)
+    if (downloadedEver > 0) {
+      percent = Math.max(percent, Math.min(Math.round((downloadedEver / sizeWhenDone) * 100), 100))
+    }
   }
   percent = Math.min(Math.max(percent, 0), 100)
   const percentWidth = Math.max((width * percent) / 100, 0)

--- a/src/components/TorrentDetail/tabs/GeneralTab.vue
+++ b/src/components/TorrentDetail/tabs/GeneralTab.vue
@@ -2,10 +2,10 @@
   <n-element class="py-3 space-y-3">
     <n-progress
       class="px-3"
-      :percentage="Math.ceil(torrent.percentDone * 100)"
+      :percentage="progressPercentage"
       type="line"
       size="large"
-      :processing="torrent.percentDone !== 1"
+      :processing="progressProcessing"
       indicator-placement="inside"
     />
     <n-card :title="t('torrentDetail.general.transmissionInfo')">
@@ -153,7 +153,7 @@
 import { computed } from 'vue'
 import type { Torrent } from '@/api/rpc'
 import { formatSpeed, formatSize, timeToStr } from '@/utils'
-import { getStatusString } from '@/types/tr'
+import { getStatusString, Status } from '@/types/tr'
 import dayjs from 'dayjs'
 import { useI18n } from 'vue-i18n'
 
@@ -162,6 +162,18 @@ const { t } = useI18n()
 const props = defineProps<{ torrent: Torrent }>()
 
 const statusText = computed(() => getStatusString(props.torrent.status) || '-')
+
+// 等待校验/校验中时展示校验进度 recheckProgress，否则展示下载进度 percentDone
+const isChecking = computed(
+  () => props.torrent.status === Status.queuedToVerify || props.torrent.status === Status.verifying
+)
+const progressPercentage = computed(() => {
+  if (isChecking.value) {
+    return Math.min(Math.max(Math.ceil((Number(props.torrent.recheckProgress) || 0) * 100), 0), 100)
+  }
+  return Math.ceil(props.torrent.percentDone * 100)
+})
+const progressProcessing = computed(() => (isChecking.value ? true : props.torrent.percentDone !== 1))
 
 function formatDate(ts?: number) {
   if (!ts) {

--- a/src/components/TorrentDetail/tabs/GeneralTab.vue
+++ b/src/components/TorrentDetail/tabs/GeneralTab.vue
@@ -154,6 +154,7 @@ import { computed } from 'vue'
 import type { Torrent } from '@/api/rpc'
 import { formatSpeed, formatSize, timeToStr } from '@/utils'
 import { getStatusString, Status } from '@/types/tr'
+import { getTorrentProgress } from '@/utils/torrentProgress'
 import dayjs from 'dayjs'
 import { useI18n } from 'vue-i18n'
 
@@ -163,17 +164,12 @@ const props = defineProps<{ torrent: Torrent }>()
 
 const statusText = computed(() => getStatusString(props.torrent.status) || '-')
 
-// 等待校验/校验中时展示校验进度 recheckProgress，否则展示下载进度 percentDone
 const isChecking = computed(
   () => props.torrent.status === Status.queuedToVerify || props.torrent.status === Status.verifying
 )
-const progressPercentage = computed(() => {
-  if (isChecking.value) {
-    return Math.min(Math.max(Math.ceil((Number(props.torrent.recheckProgress) || 0) * 100), 0), 100)
-  }
-  return Math.ceil(props.torrent.percentDone * 100)
-})
-const progressProcessing = computed(() => (isChecking.value ? true : props.torrent.percentDone !== 1))
+const progress = computed(() => getTorrentProgress(props.torrent))
+const progressPercentage = computed(() => Math.ceil(progress.value * 100))
+const progressProcessing = computed(() => isChecking.value || progress.value !== 1)
 
 function formatDate(ts?: number) {
   if (!ts) {

--- a/src/components/TorrentList/cells/PercentBarCell.vue
+++ b/src/components/TorrentList/cells/PercentBarCell.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Torrent } from '@/api/rpc'
-import { Status } from '@/types/tr'
+import { getTorrentProgress } from '@/utils/torrentProgress'
 interface Column {
   key: string
   title: string
@@ -10,18 +10,7 @@ interface Column {
 const props = defineProps<{ value: number; row: Torrent; col: Column }>()
 
 const percentage = computed(() => {
-  // 等待校验/校验中时展示校验进度 recheckProgress
-  if (props.row.status === Status.queuedToVerify || props.row.status === Status.verifying) {
-    return Math.min(Math.max(Math.round((Number(props.row.recheckProgress) || 0) * 100), 0), 100)
-  }
-  let percent = Math.round(props.value * 100)
-  // 目前 返回的数据中percentDone在下载的时候一直是 0
-  const sizeWhenDone = Number(props.row.sizeWhenDone)
-  const downloadedEver = Number(props.row.downloadedEver)
-  if (downloadedEver > 0) {
-    percent = Math.max(percent, Math.min(Math.round((downloadedEver / sizeWhenDone) * 100), 100))
-  }
-  return Math.min(Math.max(percent, 0), 100)
+  return Math.round(getTorrentProgress(props.row) * 100)
 })
 const active = computed(() => {
   return props.row.rateDownload > 0 || props.row.rateUpload > 0

--- a/src/components/TorrentList/cells/PercentBarCell.vue
+++ b/src/components/TorrentList/cells/PercentBarCell.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Torrent } from '@/api/rpc'
+import { Status } from '@/types/tr'
 interface Column {
   key: string
   title: string
@@ -9,6 +10,10 @@ interface Column {
 const props = defineProps<{ value: number; row: Torrent; col: Column }>()
 
 const percentage = computed(() => {
+  // 等待校验/校验中时展示校验进度 recheckProgress
+  if (props.row.status === Status.queuedToVerify || props.row.status === Status.verifying) {
+    return Math.min(Math.max(Math.round((Number(props.row.recheckProgress) || 0) * 100), 0), 100)
+  }
   let percent = Math.round(props.value * 100)
   // 目前 返回的数据中percentDone在下载的时候一直是 0
   const sizeWhenDone = Number(props.row.sizeWhenDone)

--- a/src/const/status.ts
+++ b/src/const/status.ts
@@ -57,6 +57,13 @@ export const statusFilters = [
     color: '#748ffc'
   },
   {
+    key: 'queuedToSeed',
+    label: (t: any) => t('statusFilter.queuedToSeed'),
+    filter: (t: Torrent) => t.status === Status.queuedToSeed,
+    icon: ClockIcon,
+    color: '#3bc9db'
+  },
+  {
     key: 'stopped',
     label: (t: any) => t('statusFilter.stopped'),
     filter: (t: Torrent) => t.status === Status.stopped,

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -170,6 +170,7 @@
   },
   "statusFilter": {
     "downloading": "Downloading",
+    "queuedToSeed": "Queued to Seed",
     "stopped": "Stopped",
     "completed": "Completed",
     "verifying": "Verifying",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -170,6 +170,7 @@
   },
   "statusFilter": {
     "downloading": "下载中",
+    "queuedToSeed": "等待做种",
     "stopped": "已暂停",
     "completed": "已完成",
     "verifying": "正在校验",

--- a/src/store/torrent.ts
+++ b/src/store/torrent.ts
@@ -39,6 +39,7 @@ const listFields = [
   'peersGettingFromUs',
   'peersSendingToUs',
   'percentDone',
+  'recheckProgress',
   'pieceCount',
   'pieceSize',
   'queuePosition',

--- a/src/store/torrentUtils.ts
+++ b/src/store/torrentUtils.ts
@@ -1,6 +1,7 @@
 import type { Torrent, TrackerStat } from '@/api/rpc'
 import { statusFilterFunMap, statusFilters } from '@/const/status'
 import { Status } from '@/types/tr'
+import { getTorrentProgress } from '@/utils/torrentProgress'
 import { ShuffleOutline } from '@vicons/ionicons5'
 import i18n from '@/i18n'
 import { isFunction } from 'lodash-es'
@@ -326,8 +327,8 @@ export const sortTorrents = function (
   sortOrder: globalThis.Ref<string, string>
 ) {
   filtered.sort((a, b) => {
-    const aValue = a[sortKey.value as keyof Torrent]
-    const bValue = b[sortKey.value as keyof Torrent]
+    const aValue = sortKey.value === 'percentDone' ? getTorrentProgress(a) : a[sortKey.value as keyof Torrent]
+    const bValue = sortKey.value === 'percentDone' ? getTorrentProgress(b) : b[sortKey.value as keyof Torrent]
     // 处理 undefined/null
     if (aValue == null && bValue == null) {
       return 0

--- a/src/utils/torrentProgress.ts
+++ b/src/utils/torrentProgress.ts
@@ -1,0 +1,25 @@
+import type { Torrent } from '@/api/rpc'
+import { Status } from '@/types/tr'
+
+const clampProgress = (value: number) => Math.min(Math.max(Number.isFinite(value) ? value : 0, 0), 1)
+
+/**
+ * 返回列表中实际展示的任务进度。
+ *
+ * 校验任务使用 recheckProgress；其他任务优先使用 percentDone，并兼容部分
+ * Transmission 服务端 percentDone 始终为 0 的情况。
+ */
+export function getTorrentProgress(torrent: Torrent): number {
+  if (torrent.status === Status.queuedToVerify || torrent.status === Status.verifying) {
+    return clampProgress(Number(torrent.recheckProgress))
+  }
+
+  const percentDone = clampProgress(Number(torrent.percentDone))
+  const sizeWhenDone = Number(torrent.sizeWhenDone)
+  const downloadedEver = Number(torrent.downloadedEver)
+  if (sizeWhenDone > 0 && downloadedEver > 0) {
+    return Math.max(percentDone, clampProgress(downloadedEver / sizeWhenDone))
+  }
+
+  return percentDone
+}


### PR DESCRIPTION
## 改动内容

### 1. 校验进度展示修复
<img width="1199" height="293" alt="image" src="https://github.com/user-attachments/assets/576876d1-7223-4c1e-8808-9152e268203c" />

校验相关状态（等待校验 queuedToVerify / 校验中 verifying）的种子，percentDone 反映的是已下载完成度（已完成种子重新校验时常为 100%），真正的校验进度在 recheckProgress 字段。校验进度这个参考qb逻辑，辅种需要关注这个进度，特别是一些大种，可能长达几个小时，这个如果一直100%没有参考意义。

- 将 recheckProgress 加入 listFields，列表轮询可获取校验进度
- 桌面 Canvas 列表、DOM 列表、移动端和详情页在校验状态下统一展示 recheckProgress

### 2. 进度排序修复
之前进度列虽然展示 recheckProgress，排序仍固定读取 percentDone，导致校验任务看起来按名称而不是当前校验百分比排序。

- 提取统一的实际展示进度计算方法
- 校验任务使用 recheckProgress
- 其他任务使用 percentDone，并保留服务端 percentDone 异常时的兼容计算
- 进度列显示和升降序排序共用同一个进度值

### 3. 新增「等待做种」状态筛选

<img width="879" height="313" alt="image" src="https://github.com/user-attachments/assets/58127a89-8aa7-4723-a7ba-aeb1516e4fbf" />

加这个等待做种是因为tr重启有时候有些种子会在这个状态，方便筛选，很多时候辅种完也是这个状态需要筛选手动强制执行。

- 侧边栏状态过滤器增加 queuedToSeed 选项
- 补充中英文文案

## 验证

- pnpm check
- 相关文件 ESLint 检查通过
