### PR TITLE
feat: 优化状态栏传输统计并支持全局限速设置

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -32,6 +32,7 @@ declare module 'vue' {
     FilesTab: typeof import('./src/components/TorrentDetail/tabs/FilesTab.vue')['default']
     FixedDecimal: typeof import('./src/components/TorrentList/cells/FixedDecimal.vue')['default']
     GeneralTab: typeof import('./src/components/TorrentDetail/tabs/GeneralTab.vue')['default']
+    GlobalSpeedLimitDialog: typeof import('./src/components/dialog/GlobalSpeedLimitDialog.vue')['default']
     HeaderMenu: typeof import('./src/components/TorrentList/HeaderMenu.vue')['default']
     IconButton: typeof import('./src/components/IconButton.vue')['default']
     IsPrivateCell: typeof import('./src/components/TorrentList/cells/IsPrivateCell.vue')['default']

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -1,9 +1,22 @@
 <template>
   <footer :class="[$style.footer, props.class]">
     <div class="flex items-start gap-1 overflow-hidden flex-1 flex-wrap h-full py-[5px]">
-      <n-tag v-for="(item, i) in allTags" :key="i" :type="item.type" size="small">{{ item.text }}</n-tag>
+      <n-tag v-for="(item, i) in infoTags" :key="i" :type="item.type" size="small">{{ item.text }}</n-tag>
     </div>
-    <div class="flex items-center gap-1 flex-shrink-0 h-full" style="width: 64px">
+    <div :class="$style.actions">
+      <button
+        v-for="item in transferItems"
+        :key="item.direction"
+        type="button"
+        :class="$style.transfer"
+        :title="item.title"
+        @click="openSpeedLimitDialog(item.direction)"
+      >
+        <n-icon :component="item.icon" :color="item.color" size="19" />
+        <span>{{ item.rate }}</span>
+        <span v-if="item.limit" :class="$style.limit">[{{ item.limit }}]</span>
+        <span :class="$style.total">({{ item.total }})</span>
+      </button>
       <n-button
         quaternary
         circle
@@ -31,9 +44,17 @@
     </div>
   </footer>
   <AboutDialog v-model:show="showAbout" :version="session?.['version']" :server="serverHost" author="..." />
+  <GlobalSpeedLimitDialog
+    v-model:show="showSpeedLimitDialog"
+    :direction="speedLimitDirection"
+    @saved="statsStore.fetchStats()"
+  />
 </template>
 <script setup lang="ts">
-import { useSessionStore, useSettingStore, useTorrentStore } from '@/store'
+import DoubleArrowDown from '@/assets/icons/doubleArrowDown.svg?component'
+import DoubleArrowUp from '@/assets/icons/doubleArrowUp.svg?component'
+import GlobalSpeedLimitDialog from '@/components/dialog/GlobalSpeedLimitDialog.vue'
+import { useSessionStore, useSettingStore, useStatsStore, useTorrentStore } from '@/store'
 import { formatSize, formatSpeed } from '@/utils'
 import { InformationCircle as InfoIcon, Moon as MoonIcon, Sunny as SunIcon } from '@vicons/ionicons5'
 import { useI18n } from 'vue-i18n'
@@ -45,6 +66,7 @@ const props = defineProps<{
 const sessionStore = useSessionStore()
 const torrentStore = useTorrentStore()
 const settingStore = useSettingStore()
+const statsStore = useStatsStore()
 const { t: $t } = useI18n()
 
 const session = computed(() => sessionStore.session)
@@ -80,24 +102,25 @@ const limit = computed(() => {
   // 提前判断 session，不存在则返回默认值
   if (!session.value) {
     return {
-      downRateLimit: -1,
-      upRateLimit: -1,
+      downRateLimit: null,
+      upRateLimit: null,
       freeSpace: 0
     }
   }
 
-  // session 存在，进行实际的逻辑判断
-  const downRateLimit = session.value['alt-speed-enabled']
-    ? (session.value['alt-speed-down'] as number)
-    : session.value['speed-limit-down-enabled']
-      ? (session.value['speed-limit-down'] as number)
-      : -1
-
-  const upRateLimit = session.value['alt-speed-enabled']
-    ? (session.value['alt-speed-up'] as number)
-    : session.value['speed-limit-up-enabled']
-      ? (session.value['speed-limit-up'] as number)
-      : -1
+  const altSpeedEnabled = Boolean(session.value['alt-speed-enabled'])
+  const getEnabledLimit = (enabled: boolean, value: unknown) => {
+    const numericValue = Number(value)
+    return enabled && Number.isFinite(numericValue) && numericValue > 0 ? numericValue : null
+  }
+  const downRateLimit = getEnabledLimit(
+    altSpeedEnabled || Boolean(session.value['speed-limit-down-enabled']),
+    altSpeedEnabled ? session.value['alt-speed-down'] : session.value['speed-limit-down']
+  )
+  const upRateLimit = getEnabledLimit(
+    altSpeedEnabled || Boolean(session.value['speed-limit-up-enabled']),
+    altSpeedEnabled ? session.value['alt-speed-up'] : session.value['speed-limit-up']
+  )
 
   const freeSpace = session.value['download-dir-free-space'] || 0
 
@@ -122,24 +145,38 @@ function onShowAbout() {
   showAbout.value = true
 }
 
-// tag 数据
-const allTags = computed(() => [
+const speedLimitDirection = ref<'download' | 'upload'>('download')
+const showSpeedLimitDialog = ref(false)
+function openSpeedLimitDialog(direction: 'download' | 'upload') {
+  speedLimitDirection.value = direction
+  showSpeedLimitDialog.value = true
+}
+
+const currentStats = computed(() => statsStore.stats?.['current-stats'])
+const transferItems = computed(() => [
+  {
+    direction: 'download' as const,
+    icon: DoubleArrowDown,
+    color: '#16a34a',
+    rate: formatSpeed(statsStore.stats?.downloadSpeed ?? computedFields.value.downRate),
+    limit: limit.value.downRateLimit === null ? '' : formatSpeed(limit.value.downRateLimit * 1024),
+    total: formatSize(currentStats.value?.downloadedBytes ?? 0),
+    title: $t('statusBar.setDownloadLimit')
+  },
+  {
+    direction: 'upload' as const,
+    icon: DoubleArrowUp,
+    color: '#3b82f6',
+    rate: formatSpeed(statsStore.stats?.uploadSpeed ?? computedFields.value.upRate),
+    limit: limit.value.upRateLimit === null ? '' : formatSpeed(limit.value.upRateLimit * 1024),
+    total: formatSize(currentStats.value?.uploadedBytes ?? 0),
+    title: $t('statusBar.setUploadLimit')
+  }
+])
+
+const infoTags = computed(() => [
   { text: $t('statusBar.version', { version: session.value?.['version'] ?? '--' }), type: 'info' as const },
   { text: $t('statusBar.server', { server: serverHost.value }), type: 'info' as const },
-  {
-    text: $t('statusBar.upload', {
-      rate: formatSpeed(computedFields.value.upRate),
-      limit: formatSpeed(limit.value.upRateLimit * 1024)
-    }),
-    type: 'success' as const
-  },
-  {
-    text: $t('statusBar.download', {
-      rate: formatSpeed(computedFields.value.downRate),
-      limit: formatSpeed(limit.value.downRateLimit * 1024)
-    }),
-    type: 'info' as const
-  },
   { text: $t('statusBar.totalSize', { size: formatSize(totalSize.value) }), type: 'info' as const },
   ...(selectedSize.value > 0
     ? [{ text: $t('statusBar.selectedSize', { size: formatSize(selectedSize.value) }), type: 'info' as const }]
@@ -160,5 +197,51 @@ const allTags = computed(() => [
   padding: 0 8px;
   border-top: 1px solid var(--border-color);
   gap: 16px;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  height: 100%;
+}
+
+.transfer {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding: 0 10px;
+  border: 0;
+  border-left: 1px solid var(--border-color);
+  color: var(--text-color-2, inherit);
+  background: transparent;
+  font: inherit;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--primary-color);
+    background: var(--hover-color, rgb(128 128 128 / 10%));
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: -2px;
+  }
+}
+
+.limit {
+  color: var(--warning-color, #d97706);
+}
+
+@media (max-width: 720px) {
+  .total {
+    display: none;
+  }
+
+  .transfer {
+    padding: 0 6px;
+  }
 }
 </style>

--- a/src/components/dialog/GlobalSpeedLimitDialog.vue
+++ b/src/components/dialog/GlobalSpeedLimitDialog.vue
@@ -1,0 +1,121 @@
+<template>
+  <n-modal
+    v-model:show="show"
+    preset="card"
+    :title="title"
+    :bordered="false"
+    :class="$style.dialog"
+    @after-enter="focusInput"
+  >
+    <n-form label-placement="left" :label-width="90">
+      <n-form-item :label="$t('speedLimitDialog.limit')">
+        <div class="flex items-center gap-2 w-full">
+          <n-input-number
+            ref="inputRef"
+            v-model:value="limitValue"
+            :min="1"
+            :precision="0"
+            :placeholder="$t('speedLimitDialog.unlimited')"
+            class="flex-1"
+            @keyup.enter="onSave"
+          />
+          <span class="whitespace-nowrap">KiB/s</span>
+        </div>
+      </n-form-item>
+      <div class="text-xs opacity-60 pl-[90px]">{{ $t('speedLimitDialog.unlimitedHint') }}</div>
+    </n-form>
+
+    <template #footer>
+      <div class="flex justify-end gap-2">
+        <n-button :disabled="loading" @click="show = false">{{ $t('common.cancel') }}</n-button>
+        <n-button type="primary" :loading="loading" @click="onSave">{{ $t('common.confirm') }}</n-button>
+      </div>
+    </template>
+  </n-modal>
+</template>
+
+<script setup lang="ts">
+import { rpc, type SessionSetArgs } from '@/api/rpc'
+import { useSessionStore } from '@/store'
+import { useMessage, type InputNumberInst } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps<{
+  direction: 'download' | 'upload'
+}>()
+const show = defineModel<boolean>('show', { required: true })
+const emit = defineEmits<{
+  saved: []
+}>()
+
+const { t: $t } = useI18n()
+const message = useMessage()
+const sessionStore = useSessionStore()
+const inputRef = ref<InputNumberInst | null>(null)
+const limitValue = ref<number | null>(null)
+const loading = ref(false)
+
+const title = computed(() =>
+  props.direction === 'download'
+    ? $t('speedLimitDialog.downloadTitle')
+    : $t('speedLimitDialog.uploadTitle')
+)
+const limitKey = computed<'speed-limit-down' | 'speed-limit-up'>(() =>
+  props.direction === 'download' ? 'speed-limit-down' : 'speed-limit-up'
+)
+const enabledKey = computed<'speed-limit-down-enabled' | 'speed-limit-up-enabled'>(() =>
+  props.direction === 'download' ? 'speed-limit-down-enabled' : 'speed-limit-up-enabled'
+)
+
+function initValue() {
+  const session = sessionStore.session
+  const enabled = Boolean(session?.[enabledKey.value])
+  const value = Number(session?.[limitKey.value])
+  limitValue.value = enabled && Number.isFinite(value) && value > 0 ? value : null
+}
+
+function focusInput() {
+  inputRef.value?.focus()
+}
+
+async function onSave() {
+  if (loading.value) {
+    return
+  }
+
+  const value = Number(limitValue.value)
+  const enabled = Number.isFinite(value) && value > 0
+  const args: SessionSetArgs = {
+    [enabledKey.value]: enabled
+  }
+  if (enabled) {
+    args[limitKey.value] = Math.round(value)
+  }
+
+  loading.value = true
+  try {
+    await rpc.sessionSet(args)
+    await sessionStore.fetchSession()
+    message.success($t('speedLimitDialog.saveSuccess'))
+    emit('saved')
+    show.value = false
+  } catch {
+    message.error($t('speedLimitDialog.saveFailed'))
+  } finally {
+    loading.value = false
+  }
+}
+
+watch([show, () => props.direction], ([visible]) => {
+  if (visible) {
+    initValue()
+  }
+})
+</script>
+
+<style module lang="less">
+.dialog {
+  width: 420px !important;
+  max-width: calc(100vw - 32px) !important;
+}
+</style>

--- a/src/components/dialog/GlobalSpeedLimitDialog.vue
+++ b/src/components/dialog/GlobalSpeedLimitDialog.vue
@@ -15,28 +15,35 @@
             v-model:value="limitValue"
             :min="1"
             :precision="0"
-            :placeholder="$t('speedLimitDialog.unlimited')"
+            :placeholder="requiresValue ? undefined : $t('speedLimitDialog.unlimited')"
             class="flex-1"
             @keyup.enter="onSave"
           />
           <span class="whitespace-nowrap">KiB/s</span>
         </div>
       </n-form-item>
-      <div class="text-xs opacity-60 pl-[90px]">{{ $t('speedLimitDialog.unlimitedHint') }}</div>
+      <div class="text-xs opacity-60 pl-[90px]">{{ hint }}</div>
     </n-form>
 
     <template #footer>
       <div class="flex justify-end gap-2">
         <n-button :disabled="loading" @click="show = false">{{ $t('common.cancel') }}</n-button>
-        <n-button type="primary" :loading="loading" @click="onSave">{{ $t('common.confirm') }}</n-button>
+        <n-button type="primary" :loading="loading" :disabled="saveDisabled" @click="onSave">{{
+          $t('common.confirm')
+        }}</n-button>
       </div>
     </template>
   </n-modal>
 </template>
 
 <script setup lang="ts">
-import { rpc, type SessionSetArgs } from '@/api/rpc'
+import { rpc } from '@/api/rpc'
 import { useSessionStore } from '@/store'
+import {
+  buildGlobalSpeedLimitArgs,
+  readGlobalSpeedLimitValue,
+  resolveGlobalSpeedLimitConfig
+} from '@/utils/globalSpeedLimit'
 import { useMessage, type InputNumberInst } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 
@@ -51,27 +58,27 @@ const emit = defineEmits<{
 const { t: $t } = useI18n()
 const message = useMessage()
 const sessionStore = useSessionStore()
-const inputRef = ref<InputNumberInst | null>(null)
-const limitValue = ref<number | null>(null)
-const loading = ref(false)
+const inputRef = useTemplateRef<InputNumberInst>('inputRef')
+const limitValue = shallowRef<number | null>(null)
+const loading = shallowRef(false)
 
 const title = computed(() =>
   props.direction === 'download'
     ? $t('speedLimitDialog.downloadTitle')
     : $t('speedLimitDialog.uploadTitle')
 )
-const limitKey = computed<'speed-limit-down' | 'speed-limit-up'>(() =>
-  props.direction === 'download' ? 'speed-limit-down' : 'speed-limit-up'
+const speedLimitConfig = computed(() =>
+  resolveGlobalSpeedLimitConfig(sessionStore.session, props.direction)
 )
-const enabledKey = computed<'speed-limit-down-enabled' | 'speed-limit-up-enabled'>(() =>
-  props.direction === 'download' ? 'speed-limit-down-enabled' : 'speed-limit-up-enabled'
+const requiresValue = computed(() => speedLimitConfig.value.requiresValue)
+const hint = computed(() =>
+  $t(requiresValue.value ? 'speedLimitDialog.altSpeedHint' : 'speedLimitDialog.unlimitedHint')
 )
+const hasValidValue = computed(() => Number.isFinite(Number(limitValue.value)) && Number(limitValue.value) > 0)
+const saveDisabled = computed(() => loading.value || (requiresValue.value && !hasValidValue.value))
 
 function initValue() {
-  const session = sessionStore.session
-  const enabled = Boolean(session?.[enabledKey.value])
-  const value = Number(session?.[limitKey.value])
-  limitValue.value = enabled && Number.isFinite(value) && value > 0 ? value : null
+  limitValue.value = readGlobalSpeedLimitValue(sessionStore.session, speedLimitConfig.value)
 }
 
 function focusInput() {
@@ -83,13 +90,10 @@ async function onSave() {
     return
   }
 
-  const value = Number(limitValue.value)
-  const enabled = Number.isFinite(value) && value > 0
-  const args: SessionSetArgs = {
-    [enabledKey.value]: enabled
-  }
-  if (enabled) {
-    args[limitKey.value] = Math.round(value)
+  const args = buildGlobalSpeedLimitArgs(speedLimitConfig.value, limitValue.value)
+  if (!args) {
+    message.warning($t('speedLimitDialog.altSpeedValueRequired'))
+    return
   }
 
   loading.value = true

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -192,8 +192,19 @@
     "totalSize": "Total Size: {size}",
     "selectedSize": "Selected Size: {size}",
     "freeSpace": "Free Space: {size}",
+    "setDownloadLimit": "Set global download limit",
+    "setUploadLimit": "Set global upload limit",
     "toggleTheme": "Toggle Theme",
     "about": "About"
+  },
+  "speedLimitDialog": {
+    "downloadTitle": "Global Download Speed Limit",
+    "uploadTitle": "Global Upload Speed Limit",
+    "limit": "Speed limit",
+    "unlimited": "∞",
+    "unlimitedHint": "Clear the input to use unlimited speed",
+    "saveSuccess": "Global speed limit updated",
+    "saveFailed": "Failed to update global speed limit"
   },
   "message": {
     "taskStarted": "Tasks started",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -203,6 +203,8 @@
     "limit": "Speed limit",
     "unlimited": "∞",
     "unlimitedHint": "Clear the input to use unlimited speed",
+    "altSpeedHint": "Alternative speed is active. Enter a positive limit or disable it in Settings.",
+    "altSpeedValueRequired": "Enter a positive alternative speed limit",
     "saveSuccess": "Global speed limit updated",
     "saveFailed": "Failed to update global speed limit"
   },

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -192,8 +192,19 @@
     "totalSize": "文件总大小: {size}",
     "selectedSize": "选中大小: {size}",
     "freeSpace": "剩余空间: {size}",
+    "setDownloadLimit": "设置全局下载限速",
+    "setUploadLimit": "设置全局上传限速",
     "toggleTheme": "切换主题",
     "about": "关于"
+  },
+  "speedLimitDialog": {
+    "downloadTitle": "全局下载速度限制",
+    "uploadTitle": "全局上传速度限制",
+    "limit": "速度限制",
+    "unlimited": "∞",
+    "unlimitedHint": "清空输入框表示不限速",
+    "saveSuccess": "全局限速已更新",
+    "saveFailed": "全局限速更新失败"
   },
   "message": {
     "taskStarted": "已开始任务",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -203,6 +203,8 @@
     "limit": "速度限制",
     "unlimited": "∞",
     "unlimitedHint": "清空输入框表示不限速",
+    "altSpeedHint": "备用带宽已启用，请输入正数限速，或前往设置关闭备用带宽。",
+    "altSpeedValueRequired": "请输入大于 0 的备用带宽限速",
     "saveSuccess": "全局限速已更新",
     "saveFailed": "全局限速更新失败"
   },

--- a/src/utils/globalSpeedLimit.test.ts
+++ b/src/utils/globalSpeedLimit.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  buildGlobalSpeedLimitArgs,
+  readGlobalSpeedLimitValue,
+  resolveGlobalSpeedLimitConfig
+} from './globalSpeedLimit.js'
+
+test('uses the active alternative download limit when alternative speed is enabled', () => {
+  const session = {
+    'alt-speed-enabled': true,
+    'alt-speed-down': 50,
+    'speed-limit-down': 100,
+    'speed-limit-down-enabled': true
+  }
+
+  const config = resolveGlobalSpeedLimitConfig(session, 'download')
+
+  assert.deepEqual(config, {
+    limitKey: 'alt-speed-down',
+    enabledKey: null,
+    requiresValue: true
+  })
+  assert.equal(readGlobalSpeedLimitValue(session, config), 50)
+})
+
+test('uses the normal upload limit and respects its enabled flag', () => {
+  const session = {
+    'alt-speed-enabled': false,
+    'speed-limit-up': 80,
+    'speed-limit-up-enabled': false
+  }
+
+  const config = resolveGlobalSpeedLimitConfig(session, 'upload')
+
+  assert.deepEqual(config, {
+    limitKey: 'speed-limit-up',
+    enabledKey: 'speed-limit-up-enabled',
+    requiresValue: false
+  })
+  assert.equal(readGlobalSpeedLimitValue(session, config), null)
+})
+
+test('builds normal and alternative session-set payloads with different empty-value behavior', () => {
+  const normalConfig = resolveGlobalSpeedLimitConfig({ 'alt-speed-enabled': false }, 'download')
+  const alternativeConfig = resolveGlobalSpeedLimitConfig({ 'alt-speed-enabled': true }, 'upload')
+
+  assert.deepEqual(buildGlobalSpeedLimitArgs(normalConfig, null), {
+    'speed-limit-down-enabled': false
+  })
+  assert.deepEqual(buildGlobalSpeedLimitArgs(normalConfig, 42.6), {
+    'speed-limit-down-enabled': true,
+    'speed-limit-down': 43
+  })
+  assert.equal(buildGlobalSpeedLimitArgs(alternativeConfig, null), null)
+  assert.deepEqual(buildGlobalSpeedLimitArgs(alternativeConfig, 64), {
+    'alt-speed-up': 64
+  })
+})

--- a/src/utils/globalSpeedLimit.ts
+++ b/src/utils/globalSpeedLimit.ts
@@ -1,0 +1,77 @@
+export type SpeedLimitDirection = 'download' | 'upload'
+
+type SpeedLimitKey = 'speed-limit-down' | 'speed-limit-up' | 'alt-speed-down' | 'alt-speed-up'
+type SpeedLimitEnabledKey = 'speed-limit-down-enabled' | 'speed-limit-up-enabled'
+
+type SpeedLimitSession = Partial<{
+  'alt-speed-enabled': boolean
+  'alt-speed-down': number
+  'alt-speed-up': number
+  'speed-limit-down': number
+  'speed-limit-down-enabled': boolean
+  'speed-limit-up': number
+  'speed-limit-up-enabled': boolean
+}>
+
+export type GlobalSpeedLimitArgs = Partial<{
+  'alt-speed-down': number
+  'alt-speed-up': number
+  'speed-limit-down': number
+  'speed-limit-down-enabled': boolean
+  'speed-limit-up': number
+  'speed-limit-up-enabled': boolean
+}>
+
+export interface GlobalSpeedLimitConfig {
+  limitKey: SpeedLimitKey
+  enabledKey: SpeedLimitEnabledKey | null
+  requiresValue: boolean
+}
+
+export function resolveGlobalSpeedLimitConfig(
+  session: SpeedLimitSession | null | undefined,
+  direction: SpeedLimitDirection
+): GlobalSpeedLimitConfig {
+  if (session?.['alt-speed-enabled']) {
+    return {
+      limitKey: direction === 'download' ? 'alt-speed-down' : 'alt-speed-up',
+      enabledKey: null,
+      requiresValue: true
+    }
+  }
+
+  return {
+    limitKey: direction === 'download' ? 'speed-limit-down' : 'speed-limit-up',
+    enabledKey: direction === 'download' ? 'speed-limit-down-enabled' : 'speed-limit-up-enabled',
+    requiresValue: false
+  }
+}
+
+export function readGlobalSpeedLimitValue(
+  session: SpeedLimitSession | null | undefined,
+  config: GlobalSpeedLimitConfig
+): number | null {
+  const enabled = config.enabledKey === null || Boolean(session?.[config.enabledKey])
+  const value = Number(session?.[config.limitKey])
+  return enabled && Number.isFinite(value) && value > 0 ? value : null
+}
+
+export function buildGlobalSpeedLimitArgs(
+  config: GlobalSpeedLimitConfig,
+  value: number | null
+): GlobalSpeedLimitArgs | null {
+  const numericValue = Number(value)
+  const enabled = Number.isFinite(numericValue) && numericValue > 0
+  if (config.requiresValue && !enabled) {
+    return null
+  }
+
+  const args: GlobalSpeedLimitArgs = {}
+  if (config.enabledKey !== null) {
+    args[config.enabledKey] = enabled
+  }
+  if (enabled) {
+    args[config.limitKey] = Math.round(numericValue)
+  }
+  return args
+}


### PR DESCRIPTION
## 改动内容

### 1. 优化状态栏上传/下载信息
<img width="420" height="133" alt="image" src="https://github.com/user-attachments/assets/ef91a722-3ff7-4af8-80a0-0a3ff527b838" />
<img width="479" height="116" alt="image" src="https://github.com/user-attachments/assets/585e830c-c315-4be8-b1e0-55ff3ae695a8" />

- 参考 qBittorrent，将下载和上传速率改为紧凑的双箭头样式
- 使用 session-stats 返回的全局实时速率和本次会话累计流量
- 仅在启用限速时显示方括号中的当前生效限速
- 修复不限速时显示 -1024 B/S 的问题
- 小屏幕下隐藏累计流量，保留速率和限速信息

### 2. 支持从状态栏设置全局限速
<img width="626" height="283" alt="image" src="https://github.com/user-attachments/assets/790ce6fb-8171-41a0-91f8-51be383b34bd" />

- 点击下载或上传速率可打开对应的全局限速弹窗
- 限速单位为 KiB/s
- 清空输入框即可恢复不限速
- 保存后调用 session-set，并刷新会话数据和状态栏统计

### 3. 国际化

- 补充全局上传/下载限速弹窗的中英文文案

## 验证

- pnpm check
- 定向 ESLint 检查
- pnpm build:prod
- 生产构建基础路径 /transmission/web 验证通过

## 说明

该 PR 从上游 main 独立创建，不包含 PR #33 的校验进度相关改动。
